### PR TITLE
[BUGFIX] Module ilo_boot_order: fixed "type object ILOBootOrder has n…

### DIFF
--- a/changelogs/bugfix-ilo-boot-order-endpoint.yml
+++ b/changelogs/bugfix-ilo-boot-order-endpoint.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Module ilo_boot_order: Fixes bug "type object 'ILOBootOrder' has no attribute 'ENDPOINT'"

--- a/plugins/modules/ilo_boot_order.py
+++ b/plugins/modules/ilo_boot_order.py
@@ -90,7 +90,7 @@ class ILOBootOrder(RedfishModuleBase):
 
         if not self.module.check_mode and current_pending_order != new_order:
             self.result["response"] = self.api_client.patch_request(
-                ILOBootOrder.ENDPOINT, {"PersistentBootConfigOrder": new_order}
+                "Systems/1/Bios/boot/settings", {"PersistentBootConfigOrder": new_order}
             )
 
     def compute_new_order(self, settings):


### PR DESCRIPTION
…o attribute ENDPOINT"