### PR TITLE
[UPDATE] workflow release: create tag alias using prefix v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,15 @@ jobs:
               ref: "refs/tags/${{ env.VERSION }}",
               sha: context.sha
             })
+
+      - name: Create tag alias (using prefix v)
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/v${{ env.VERSION }}",
+              sha: context.sha
+            })


### PR DESCRIPTION
antsibull-changelog seems to require release tags like vX.X.X, at least it creates links using this version format, even if the release is specified as X.X.X.

As a workaround we will create both tags.