### PR TITLE
[UPDATE] ci pipeline: use python version in matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ env:
 
 jobs:
   sanity:
-    name: Sanity (Ansible ${{ matrix.ansible }})
+    name: Sanity (Ansible ${{ matrix.ansible }}-${{ matrix.python }})
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - ubuntu-latest
@@ -32,6 +33,26 @@ jobs:
           - stable-2.11
           - stable-2.12
           #- devel
+        python:
+          # - '2.6' not supported
+          - '2.7'
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+        exclude:
+          # Because ansible-test doesn't support Python 3.9 for Ansible 2.9
+          # and Python 3.10 is supported in 2.12 or later.
+          - ansible: stable-2.9
+            python: '3.9'
+          - ansible: stable-2.9
+            python: '3.10'
+          - ansible: stable-2.10
+            python: '3.10'
+          - ansible: stable-2.11
+            python: '3.10'
     steps:
       # ansible-test requires the collection to be in a directory in the form
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
@@ -40,7 +61,7 @@ jobs:
         with:
           env: |
             COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
-            TEST_INVOCATION="sanity --docker ${{ matrix.test_container }} --exclude dev_tools/**.py -v --color --coverage"
+            TEST_INVOCATION="sanity --docker ${{ matrix.test_container }} --python {{ matrix.python }} --exclude dev_tools/**.py -v --color --coverage"
 
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
We want to keep sanity checks for ansible 2.9, but without specifying the python version, this will run checks against python 2.6, which we don't support.